### PR TITLE
Caco 305 refactor code and permission on user management subsystem pages be

### DIFF
--- a/models/user.py
+++ b/models/user.py
@@ -8,7 +8,6 @@ from models.base import ModelConfig, PyObjectId
 class Role(str, Enum):
     ADMIN = "Admin"
     NURSE = "Nurse"
-    FAMILY = "Family"
 
 
 class Gender(str, Enum):


### PR DESCRIPTION
This pull request includes several updates to the user management functionality. The changes introduce a new `UserUpdate` model, enforce role-based access control for certain endpoints, and remove unused code.

**Model and Schema Updates:**

* Added a new `UserUpdate` model to handle partial user updates (`models/user.py`).

**Role-Based Access Control:**

* Enforced "Admin" role requirement for `create_user` and `delete_user_by_id` endpoints (`routers/user.py`) [[1]](diffhunk://#diff-78dc28fba38afcfbb0579439e6751c1f5fc706e926b050eb58d21c69e6a2c048L36-R42) [[2]](diffhunk://#diff-78dc28fba38afcfbb0579439e6751c1f5fc706e926b050eb58d21c69e6a2c048L108-L120).
* Updated `update_user_details` to allow updates by either an Admin or the user themselves (`routers/user.py`).

**Code Cleanup:**

* Removed the unused `get_user_by_email_service` import and corresponding endpoint (`routers/user.py`) [[1]](diffhunk://#diff-78dc28fba38afcfbb0579439e6751c1f5fc706e926b050eb58d21c69e6a2c048L15) [[2]](diffhunk://#diff-78dc28fba38afcfbb0579439e6751c1f5fc706e926b050eb58d21c69e6a2c048L108-L120).

**Rate Limiting Adjustments:**

* Commented out rate limiting for `get_current_user_details` and `get_current_user_role` endpoints (`routers/user.py`) [[1]](diffhunk://#diff-78dc28fba38afcfbb0579439e6751c1f5fc706e926b050eb58d21c69e6a2c048L60-R66) [[2]](diffhunk://#diff-78dc28fba38afcfbb0579439e6751c1f5fc706e926b050eb58d21c69e6a2c048L69-R75).

These changes collectively improve the user management system by introducing more flexible update capabilities, enhancing security through role-based access control, and cleaning up the codebase.