### PR TITLE
feat: add optional photograph field to resident registration models and enforce admin role for updates

### DIFF
--- a/models/resident.py
+++ b/models/resident.py
@@ -5,6 +5,7 @@ from models.base import PyObjectId, ModelConfig
 
 
 class RegistrationCreate(BaseModel):
+    photograph: Optional[str] = None
     full_name: str
     gender: str
     date_of_birth: date
@@ -20,6 +21,7 @@ class RegistrationCreate(BaseModel):
 
 class RegistrationResponse(ModelConfig):
     id: Optional[PyObjectId] = Field(alias="_id", default=None)
+    photograph: Optional[str] = None
     full_name: str
     gender: str
     date_of_birth: date

--- a/routers/resident.py
+++ b/routers/resident.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends, Request, Query
 from models.resident import RegistrationCreate, RegistrationResponse
-from typing import List, Optional
+from typing import List, Optional, Dict
 from services.resident_service import (
     create_residentInfo,
     get_all_residents,
@@ -10,6 +10,7 @@ from services.resident_service import (
     delete_resident,
     get_all_residents_by_nurse,
 )
+from services.user_service import require_roles
 from db.connection import get_db
 from utils.limiter import limiter
 
@@ -97,7 +98,9 @@ async def update_resident_record(
     resident_id: str,
     update_data: RegistrationCreate,
     db=Depends(get_db),
+    current_user: Dict = Depends(require_roles(["Admin"])),
 ):
+
     return await update_resident(db, resident_id, update_data)
 
 


### PR DESCRIPTION
This pull request includes several changes to the `models/resident.py` and `routers/resident.py` files to enhance the resident registration and update processes. The most important changes include adding a new optional field for photographs, importing additional modules, and updating the resident record endpoint to require admin roles.

Enhancements to resident registration:

* [`models/resident.py`](diffhunk://#diff-bd4c947e964a6955c890a023795c2ad7385a9c79daef9a5eec36b4b28c4e3fe9R8): Added an optional `photograph` field to the `RegistrationCreate` and `RegistrationResponse` classes. [[1]](diffhunk://#diff-bd4c947e964a6955c890a023795c2ad7385a9c79daef9a5eec36b4b28c4e3fe9R8) [[2]](diffhunk://#diff-bd4c947e964a6955c890a023795c2ad7385a9c79daef9a5eec36b4b28c4e3fe9R24)

Codebase improvements:

* [`routers/resident.py`](diffhunk://#diff-b40f30cc9e938156258c6eae106498c96431eb2dff98cb28fb916f5e293a2794L3-R3): Imported the `Dict` type from `typing` to support type annotations.
* [`routers/resident.py`](diffhunk://#diff-b40f30cc9e938156258c6eae106498c96431eb2dff98cb28fb916f5e293a2794R13): Imported the `require_roles` function from `services.user_service` to enforce role-based access control.
* [`routers/resident.py`](diffhunk://#diff-b40f30cc9e938156258c6eae106498c96431eb2dff98cb28fb916f5e293a2794R101-R103): Updated the `update_resident_record` endpoint to require an admin role for access.