### PR TITLE
refactor: added a secondary database and seperated caregiver/nurse's data

### DIFF
--- a/api/index.py
+++ b/api/index.py
@@ -1,9 +1,9 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 
-from db.connection import lifespan
+from db.connection import lifespan, get_db, get_resident_db
 from routers.activity import router as activity_router
 from routers.cloudinary.image import router as image_router
 from routers.group import router as group_router
@@ -18,6 +18,7 @@ from routers.task import router as task_router
 from routers.user import router as user_router
 from utils.config import FE_URL
 from utils.limiter import limiter
+
 
 app = FastAPI(root_path="/api/v1", lifespan=lifespan)
 
@@ -49,3 +50,43 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 @app.get("/")
 def read_root():
     return {"status": "Server is healthy"}
+
+
+async def migrate_collection(source_db, target_db, collection_name):
+    """
+    Migrates a collection from source to target database while preserving ObjectIDs.
+
+    Args:
+        source_db: Source AsyncIOMotorDatabase
+        target_db: Target AsyncIOMotorDatabase
+        collection_name: Name of the collection to migrate
+    """
+    try:
+        # Get all documents from source collection
+        documents = await source_db[collection_name].find({}).to_list(None)
+
+        if documents:
+            # Insert all documents to target collection
+            # This preserves the _id and all other fields exactly as they were
+            await target_db[collection_name].insert_many(documents)
+
+        print(
+            f"✅ Successfully migrated {len(documents)} documents from {collection_name}"
+        )
+
+    except Exception as e:
+        print(f"❌ Migration failed for {collection_name}: {str(e)}")
+
+
+@app.post("/migrate-collection/{collection_name}")
+async def migrate_collection_endpoint(
+    collection_name: str,
+    request: Request,
+):
+
+    target_db = await get_db(request)
+    source_db = await get_resident_db(request)
+
+    await migrate_collection(source_db, target_db, collection_name)
+
+    return {"message": f"Migration of {collection_name} completed successfully"}

--- a/routers/health_record/medical_history.py
+++ b/routers/health_record/medical_history.py
@@ -1,7 +1,7 @@
 from typing import Union, List
 from fastapi import APIRouter, Depends, Request, Query
 from motor.motor_asyncio import AsyncIOMotorDatabase
-from db.connection import get_db
+from db.connection import get_resident_db
 from models.medical_history import (
     ConditionRecord,
     AllergyRecord,
@@ -37,7 +37,7 @@ async def create_medical_record(
     template_type: str,
     record: dict,
     resident_id: str = Query(..., description="Resident ID linked to the record"),
-    db: AsyncIOMotorDatabase = Depends(get_db),
+    db: AsyncIOMotorDatabase = Depends(get_resident_db),
 ):
     return await create_medical_history_by_template(
         db, template_type, resident_id, record
@@ -62,7 +62,7 @@ async def update_medical_record(
     record_id: str,
     record: dict,
     resident_id: str = Query(..., description="Resident ID linked to the record"),
-    db: AsyncIOMotorDatabase = Depends(get_db),
+    db: AsyncIOMotorDatabase = Depends(get_resident_db),
 ):
     return await update_medical_record_by_type(
         db, template_type, resident_id, record_id, record
@@ -72,7 +72,7 @@ async def update_medical_record(
 @router.delete("/{record_id}")
 @limiter.limit("10/second")
 async def delete_medical_record(
-    request: Request, record_id: str, db: AsyncIOMotorDatabase = Depends(get_db)
+    request: Request, record_id: str, db: AsyncIOMotorDatabase = Depends(get_resident_db)
 ):
     return await delete_medical_record_by_id(db, record_id)
 
@@ -92,6 +92,6 @@ async def delete_medical_record(
 )
 @limiter.limit("10/second")
 async def get_medical_records_by_resident_endpoint(
-    request: Request, resident_id: str, db: AsyncIOMotorDatabase = Depends(get_db)
+    request: Request, resident_id: str, db: AsyncIOMotorDatabase = Depends(get_resident_db)
 ):
     return await get_medical_records_by_resident(db, resident_id)

--- a/routers/resident.py
+++ b/routers/resident.py
@@ -11,7 +11,7 @@ from services.resident_service import (
     get_all_residents_by_nurse,
 )
 from services.user_service import require_roles
-from db.connection import get_db
+from db.connection import get_resident_db
 from utils.limiter import limiter
 
 router = APIRouter(prefix="/residents", tags=["Resident Records"])
@@ -20,7 +20,7 @@ router = APIRouter(prefix="/residents", tags=["Resident Records"])
 @router.post("/createNewRecord")
 @limiter.limit("10/minute")
 async def create_resident_record(
-    request: Request, registration: RegistrationCreate, db=Depends(get_db)
+    request: Request, registration: RegistrationCreate, db=Depends(get_resident_db)
 ):
     return await create_residentInfo(db, registration)
 
@@ -33,7 +33,7 @@ async def create_resident_record(
 @limiter.limit("100/minute")
 async def list_residents(
     request: Request,
-    db=Depends(get_db),
+    db=Depends(get_resident_db),
     nurse: Optional[str] = None,  # e.g. /residents?nurse=Alice
 ):
     if nurse:
@@ -48,7 +48,7 @@ async def list_residents(
 @limiter.limit("100/minute")
 async def list_residents(
     request: Request,
-    db=Depends(get_db),
+    db=Depends(get_resident_db),
     nurse: Optional[str] = None,
     page: Optional[int] = 1,  # default to page 1 if not provided
 ):
@@ -76,7 +76,7 @@ async def list_residents(
 async def search_residents(
     request: Request,
     name: str = Query(..., description="Substring to search in resident names"),
-    db=Depends(get_db),
+    db=Depends(get_resident_db),
 ):
     return await get_residents_by_name(db, name)
 
@@ -85,7 +85,9 @@ async def search_residents(
     "/{resident_id}", response_model=RegistrationResponse, response_model_by_alias=False
 )
 @limiter.limit("100/minute")
-async def view_resident_by_id(request: Request, resident_id: str, db=Depends(get_db)):
+async def view_resident_by_id(
+    request: Request, resident_id: str, db=Depends(get_resident_db)
+):
     return await get_resident_by_id(db, resident_id)
 
 
@@ -97,7 +99,7 @@ async def update_resident_record(
     request: Request,
     resident_id: str,
     update_data: RegistrationCreate,
-    db=Depends(get_db),
+    db=Depends(get_resident_db),
     current_user: Dict = Depends(require_roles(["Admin"])),
 ):
 
@@ -107,6 +109,6 @@ async def update_resident_record(
 @router.delete("/{resident_id}")
 @limiter.limit("10/minute")
 async def delete_resident_record(
-    request: Request, resident_id: str, db=Depends(get_db)
+    request: Request, resident_id: str, db=Depends(get_resident_db)
 ):
     return await delete_resident(db, resident_id)

--- a/routers/tag.py
+++ b/routers/tag.py
@@ -1,7 +1,7 @@
 from typing import List, Optional
 from fastapi import APIRouter, Depends, Request
 
-from db.connection import get_db
+from db.connection import get_resident_db, get_db
 from models.resident import ResidentTagResponse
 from models.user import UserTagResponse
 from services.resident_service import get_resident_tags
@@ -22,7 +22,7 @@ async def search_resident_tags(
     request: Request,
     search_key: Optional[str] = None,
     limit: int = 10,
-    db=Depends(get_db),
+    db=Depends(get_resident_db),
 ):
     return await get_resident_tags(search_key, limit, db)
 


### PR DESCRIPTION
This pull request includes significant changes to the database connection management and introduces a new endpoint for migrating collections. The primary focus is on differentiating between primary and secondary databases and updating the relevant dependencies across multiple files.

Database connection management:

* [`db/connection.py`](diffhunk://#diff-83a19dcd2e6125aea947f8aa3b496080ed74b31582f6bc37c2cae91ced4cb813L8-R12): Introduced new functions `get_resident_db` and updated `get_db` to return the primary database. Modified the `lifespan` function to connect to both primary and secondary databases. [[1]](diffhunk://#diff-83a19dcd2e6125aea947f8aa3b496080ed74b31582f6bc37c2cae91ced4cb813L8-R12) [[2]](diffhunk://#diff-83a19dcd2e6125aea947f8aa3b496080ed74b31582f6bc37c2cae91ced4cb813L17-R39)

New migration endpoint:

* [`api/index.py`](diffhunk://#diff-b014e93fcab9bae29f453d7a616da5eac2f02947f32d02a1a1bf200eeaab5a39R53-R92): Added a new asynchronous function `migrate_collection` and an endpoint `migrate_collection_endpoint` to handle the migration of collections between databases.

Dependency updates:

* [`routers/health_record/medical_history.py`](diffhunk://#diff-8fcb9526e20b72ddf5a5e540d7cfb62d9ba6fbf4783022997464d8e4ea39e793L4-R4): Updated all database dependencies to use `get_resident_db` instead of `get_db` for resident-related operations. [[1]](diffhunk://#diff-8fcb9526e20b72ddf5a5e540d7cfb62d9ba6fbf4783022997464d8e4ea39e793L4-R4) [[2]](diffhunk://#diff-8fcb9526e20b72ddf5a5e540d7cfb62d9ba6fbf4783022997464d8e4ea39e793L40-R40) [[3]](diffhunk://#diff-8fcb9526e20b72ddf5a5e540d7cfb62d9ba6fbf4783022997464d8e4ea39e793L65-R65) [[4]](diffhunk://#diff-8fcb9526e20b72ddf5a5e540d7cfb62d9ba6fbf4783022997464d8e4ea39e793L75-R75) [[5]](diffhunk://#diff-8fcb9526e20b72ddf5a5e540d7cfb62d9ba6fbf4783022997464d8e4ea39e793L95-R95)
* [`routers/resident.py`](diffhunk://#diff-b40f30cc9e938156258c6eae106498c96431eb2dff98cb28fb916f5e293a2794L14-R14): Updated all database dependencies to use `get_resident_db` instead of `get_db` for resident-related operations. [[1]](diffhunk://#diff-b40f30cc9e938156258c6eae106498c96431eb2dff98cb28fb916f5e293a2794L14-R14) [[2]](diffhunk://#diff-b40f30cc9e938156258c6eae106498c96431eb2dff98cb28fb916f5e293a2794L23-R23) [[3]](diffhunk://#diff-b40f30cc9e938156258c6eae106498c96431eb2dff98cb28fb916f5e293a2794L36-R36) [[4]](diffhunk://#diff-b40f30cc9e938156258c6eae106498c96431eb2dff98cb28fb916f5e293a2794L51-R51) [[5]](diffhunk://#diff-b40f30cc9e938156258c6eae106498c96431eb2dff98cb28fb916f5e293a2794L79-R79) [[6]](diffhunk://#diff-b40f30cc9e938156258c6eae106498c96431eb2dff98cb28fb916f5e293a2794L88-R90) [[7]](diffhunk://#diff-b40f30cc9e938156258c6eae106498c96431eb2dff98cb28fb916f5e293a2794L100-R102) [[8]](diffhunk://#diff-b40f30cc9e938156258c6eae106498c96431eb2dff98cb28fb916f5e293a2794L110-R112)
* [`routers/tag.py`](diffhunk://#diff-75087a8fcd18449bea8f87c9e9a9039c1b354655c7191c9a4d24bbade3ff959aL4-R4): Updated the `search_resident_tags` function to use `get_resident_db` for database dependency. [[1]](diffhunk://#diff-75087a8fcd18449bea8f87c9e9a9039c1b354655c7191c9a4d24bbade3ff959aL4-R4) [[2]](diffhunk://#diff-75087a8fcd18449bea8f87c9e9a9039c1b354655c7191c9a4d24bbade3ff959aL25-R25)

Task service updates:

* [`services/task_service.py`](diffhunk://#diff-1cb27d9073a94307086680121fce00a3b3ca5fc27660706ebbc7f33d15b3d0f8L5-R10): Modified the `enrich_task_with_names` and `enrich_task_with_room` functions to use `get_resident_db` for fetching resident-related information. [[1]](diffhunk://#diff-1cb27d9073a94307086680121fce00a3b3ca5fc27660706ebbc7f33d15b3d0f8L5-R10) [[2]](diffhunk://#diff-1cb27d9073a94307086680121fce00a3b3ca5fc27660706ebbc7f33d15b3d0f8L369-R374) [[3]](diffhunk://#diff-1cb27d9073a94307086680121fce00a3b3ca5fc27660706ebbc7f33d15b3d0f8L393-R401)