### PR TITLE
refactor: replace get_db with get_resident_db in careplan, medication and wellness report routers

### DIFF
--- a/routers/health_record/careplan.py
+++ b/routers/health_record/careplan.py
@@ -8,7 +8,7 @@ from services.careplan_service import (
     update_careplan,
     delete_careplan,
 )
-from db.connection import get_db
+from db.connection import get_resident_db
 from utils.limiter import limiter
 
 router = APIRouter(prefix="/residents/{resident_id}/careplan", tags=["Careplan"])
@@ -17,14 +17,19 @@ router = APIRouter(prefix="/residents/{resident_id}/careplan", tags=["Careplan"]
 @router.post("/", response_model=CarePlanResponse, response_model_by_alias=False)
 @limiter.limit("10/minute")
 async def add_careplan(
-    request: Request, resident_id: str, careplan: CarePlanCreate, db=Depends(get_db)
+    request: Request,
+    resident_id: str,
+    careplan: CarePlanCreate,
+    db=Depends(get_resident_db),
 ):
     return await create_careplan(db, resident_id, careplan)
 
 
 @router.get("/", response_model=List[CarePlanResponse], response_model_by_alias=False)
 @limiter.limit("100/minute")
-async def list_careplans(request: Request, resident_id: str, db=Depends(get_db)):
+async def list_careplans(
+    request: Request, resident_id: str, db=Depends(get_resident_db)
+):
     return await get_careplans_by_resident(db, resident_id)
 
 
@@ -33,7 +38,7 @@ async def list_careplans(request: Request, resident_id: str, db=Depends(get_db))
 )
 @limiter.limit("100/minute")
 async def get_careplan(
-    request: Request, resident_id: str, careplan_id: str, db=Depends(get_db)
+    request: Request, resident_id: str, careplan_id: str, db=Depends(get_resident_db)
 ):
     return await get_careplan_by_id(db, resident_id, careplan_id)
 
@@ -47,7 +52,7 @@ async def update_careplan_record(
     resident_id: str,
     careplan_id: str,
     update_data: CarePlanCreate,
-    db=Depends(get_db),
+    db=Depends(get_resident_db),
 ):
     return await update_careplan(db, resident_id, careplan_id, update_data)
 
@@ -55,6 +60,6 @@ async def update_careplan_record(
 @router.delete("/{careplan_id}", status_code=status.HTTP_204_NO_CONTENT)
 @limiter.limit("10/minute")
 async def delete_careplan_record(
-    request: Request, resident_id: str, careplan_id: str, db=Depends(get_db)
+    request: Request, resident_id: str, careplan_id: str, db=Depends(get_resident_db)
 ):
     return await delete_careplan(db, resident_id, careplan_id)

--- a/routers/health_record/medication.py
+++ b/routers/health_record/medication.py
@@ -8,7 +8,7 @@ from services.medication_service import (
     update_medication,
     delete_medication,
 )
-from db.connection import get_db
+from db.connection import get_resident_db
 from utils.limiter import limiter
 
 router = APIRouter(prefix="/residents/{resident_id}/medications", tags=["Medications"])
@@ -17,14 +17,19 @@ router = APIRouter(prefix="/residents/{resident_id}/medications", tags=["Medicat
 @router.post("/", response_model=MedicationResponse, response_model_by_alias=False)
 @limiter.limit("10/minute")
 async def add_medication(
-    request: Request, resident_id: str, medication: MedicationCreate, db=Depends(get_db)
+    request: Request,
+    resident_id: str,
+    medication: MedicationCreate,
+    db=Depends(get_resident_db),
 ):
     return await create_medication(db, resident_id, medication)
 
 
 @router.get("/", response_model=List[MedicationResponse], response_model_by_alias=False)
 @limiter.limit("100/minute")
-async def list_medications(request: Request, resident_id: str, db=Depends(get_db)):
+async def list_medications(
+    request: Request, resident_id: str, db=Depends(get_resident_db)
+):
     return await get_medications_by_resident(db, resident_id)
 
 
@@ -33,7 +38,7 @@ async def list_medications(request: Request, resident_id: str, db=Depends(get_db
 )
 @limiter.limit("100/minute")
 async def get_medication(
-    request: Request, resident_id: str, medication_id: str, db=Depends(get_db)
+    request: Request, resident_id: str, medication_id: str, db=Depends(get_resident_db)
 ):
     return await get_medication_by_id(db, resident_id, medication_id)
 
@@ -47,7 +52,7 @@ async def update_medication_record(
     resident_id: str,
     medication_id: str,
     update_data: MedicationCreate,
-    db=Depends(get_db),
+    db=Depends(get_resident_db),
 ):
     return await update_medication(db, resident_id, medication_id, update_data)
 
@@ -55,6 +60,6 @@ async def update_medication_record(
 @router.delete("/{medication_id}", status_code=status.HTTP_204_NO_CONTENT)
 @limiter.limit("10/minute")
 async def delete_medication_record(
-    request: Request, resident_id: str, medication_id: str, db=Depends(get_db)
+    request: Request, resident_id: str, medication_id: str, db=Depends(get_resident_db)
 ):
     return await delete_medication(db, resident_id, medication_id)

--- a/routers/wellness_report.py
+++ b/routers/wellness_report.py
@@ -8,7 +8,7 @@ from services.wellness_report_service import (
     update_wellness_report,
     delete_wellness_report,
 )
-from db.connection import get_db
+from db.connection import get_resident_db
 from utils.limiter import limiter
 
 router = APIRouter(
@@ -19,7 +19,10 @@ router = APIRouter(
 @router.post("/", response_model=WellnessReportResponse, response_model_by_alias=False)
 @limiter.limit("10/minute")
 async def add_report(
-    request: Request, resident_id: str, report: WellnessReportCreate, db=Depends(get_db)
+    request: Request,
+    resident_id: str,
+    report: WellnessReportCreate,
+    db=Depends(get_resident_db),
 ):
     return await create_wellness_report(db, resident_id, report)
 
@@ -28,7 +31,7 @@ async def add_report(
     "/", response_model=List[WellnessReportResponse], response_model_by_alias=False
 )
 @limiter.limit("100/minute")
-async def list_reports(request: Request, resident_id: str, db=Depends(get_db)):
+async def list_reports(request: Request, resident_id: str, db=Depends(get_resident_db)):
     return await get_reports_by_resident(db, resident_id)
 
 
@@ -37,7 +40,7 @@ async def list_reports(request: Request, resident_id: str, db=Depends(get_db)):
 )
 @limiter.limit("100/minute")
 async def get_report(
-    request: Request, resident_id: str, report_id: str, db=Depends(get_db)
+    request: Request, resident_id: str, report_id: str, db=Depends(get_resident_db)
 ):
     return await get_wellness_report_by_id(db, resident_id, report_id)
 
@@ -51,7 +54,7 @@ async def update_report(
     resident_id: str,
     report_id: str,
     update_data: WellnessReportCreate,
-    db=Depends(get_db),
+    db=Depends(get_resident_db),
 ):
     return await update_wellness_report(db, resident_id, report_id, update_data)
 
@@ -59,6 +62,6 @@ async def update_report(
 @router.delete("/{report_id}", status_code=status.HTTP_204_NO_CONTENT)
 @limiter.limit("10/minute")
 async def delete_report(
-    request: Request, resident_id: str, report_id: str, db=Depends(get_db)
+    request: Request, resident_id: str, report_id: str, db=Depends(get_resident_db)
 ):
     return await delete_wellness_report(db, resident_id, report_id)


### PR DESCRIPTION
This pull request includes changes to the database dependency injection for the `careplan`, `medication`, and `wellness_report` routers to use the `get_resident_db` function instead of `get_db`. This ensures that the correct database connection is used for resident-specific data.

Changes in `careplan` router:

* Updated import statement to use `get_resident_db` instead of `get_db` (`routers/health_record/careplan.py`).
* Modified all endpoint functions to use `db=Depends(get_resident_db)` instead of `db=Depends(get_db)` (`routers/health_record/careplan.py`) [[1]](diffhunk://#diff-abcfc575fe87e04aec0916ba849930a848aff736b4d478a1e38e1b241d6f88d1L20-R32) [[2]](diffhunk://#diff-abcfc575fe87e04aec0916ba849930a848aff736b4d478a1e38e1b241d6f88d1L36-R41) [[3]](diffhunk://#diff-abcfc575fe87e04aec0916ba849930a848aff736b4d478a1e38e1b241d6f88d1L50-R63).

Changes in `medication` router:

* Updated import statement to use `get_resident_db` instead of `get_db` (`routers/health_record/medication.py`).
* Modified all endpoint functions to use `db=Depends(get_resident_db)` instead of `db=Depends(get_db)` (`routers/health_record/medication.py`) [[1]](diffhunk://#diff-c4204cc76e848e9d0d409280b72deb827ee3fbb440762d5726762ea248f9a186L20-R32) [[2]](diffhunk://#diff-c4204cc76e848e9d0d409280b72deb827ee3fbb440762d5726762ea248f9a186L36-R41) [[3]](diffhunk://#diff-c4204cc76e848e9d0d409280b72deb827ee3fbb440762d5726762ea248f9a186L50-R63).

Changes in `wellness_report` router:

* Updated import statement to use `get_resident_db` instead of `get_db` (`routers/wellness_report.py`).
* Modified all endpoint functions to use `db=Depends(get_resident_db)` instead of `db=Depends(get_db)` (`routers/wellness_report.py`) [[1]](diffhunk://#diff-fd783a6adb7330211868d73c0cfc285897385766e1db92ff1d7c42121e2676a1L22-R25) [[2]](diffhunk://#diff-fd783a6adb7330211868d73c0cfc285897385766e1db92ff1d7c42121e2676a1L31-R34) [[3]](diffhunk://#diff-fd783a6adb7330211868d73c0cfc285897385766e1db92ff1d7c42121e2676a1L40-R43) [[4]](diffhunk://#diff-fd783a6adb7330211868d73c0cfc285897385766e1db92ff1d7c42121e2676a1L54-R65).