### PR TITLE
fix: refresh token

### DIFF
--- a/auth/jwttoken.py
+++ b/auth/jwttoken.py
@@ -30,16 +30,27 @@ def refresh_access_token(refresh_token: str) -> dict:
         role = payload.get("role")
         if user_id is None or email is None or role is None:
             raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+        new_access_token = create_access_token(
+            data={"id": user_id, "sub": email, "role": role}
+        )
+
+        new_refresh_token = create_refresh_token(
+            data={"id": user_id, "sub": email, "role": role}
+        )
+
+        return {
+            "access_token": new_access_token,
+            "refresh_token": new_refresh_token,
+            "token_type": "bearer",
+        }
+
     except jwt.ExpiredSignatureError:
         raise HTTPException(status_code=401, detail="Refresh token expired")
-    except JWTError:
+    except JWTError as e:
         raise HTTPException(status_code=401, detail="Invalid refresh token")
-
-    new_access_token = create_access_token(
-        data={"id": user_id, "sub": email, "role": role}
-    )
-
-    return {"access_token": new_access_token, "token_type": "bearer"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail="Internal server error")
 
 
 def verify_token(token: str, credentials_exception):


### PR DESCRIPTION
This pull request includes a significant update to the `refresh_access_token` function in the `auth/jwttoken.py` file. The changes improve the handling of refresh tokens and add better error handling.

Key changes:

* Improved token generation:
  * Added creation of a new refresh token along with the access token. (`auth/jwttoken.py`, [auth/jwttoken.pyL33-R53](diffhunk://#diff-80fca4aa38fc0394b8811069af96ddd7659b2b578aa3724cdc9bc53a3fe417c2L33-R53))
  * Modified the return statement to include the new refresh token. (`auth/jwttoken.py`, [auth/jwttoken.pyL33-R53](diffhunk://#diff-80fca4aa38fc0394b8811069af96ddd7659b2b578aa3724cdc9bc53a3fe417c2L33-R53))

* Enhanced error handling:
  * Added a general exception handler to catch unexpected errors and return a 500 status code with an "Internal server error" message. (`auth/jwttoken.py`, [auth/jwttoken.pyL33-R53](diffhunk://#diff-80fca4aa38fc0394b8811069af96ddd7659b2b578aa3724cdc9bc53a3fe417c2L33-R53))
  * Moved the specific `jwt.ExpiredSignatureError` and `JWTError` handlers to the end of the try-except block to ensure they are not overridden by the general exception handler. (`auth/jwttoken.py`, [auth/jwttoken.pyL33-R53](diffhunk://#diff-80fca4aa38fc0394b8811069af96ddd7659b2b578aa3724cdc9bc53a3fe417c2L33-R53))