### PR TITLE
Caco 285 approve a report be

### DIFF
--- a/models/report.py
+++ b/models/report.py
@@ -37,7 +37,11 @@ class ReportReview(ReportReviewCreate):
     resolution: Optional[str] = None
     status: ReportReviewStatus
     reviewed_at: Optional[datetime] = None
-    resolved_at:  Optional[datetime] = None
+    resolved_at: Optional[datetime] = None
+
+
+class ResolveReportRequest(BaseModel):
+    resolution: str
 
 
 class ReportCreate(BaseModel):

--- a/routers/incident/report.py
+++ b/routers/incident/report.py
@@ -1,10 +1,14 @@
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Request
-from pydantic import BaseModel
 
 from db.connection import get_db
-from models.report import ReportCreate, ReportResponse, ReportReviewCreate
+from models.report import (
+    ReportCreate,
+    ReportResponse,
+    ReportReviewCreate,
+    ResolveReportRequest,
+)
 from services.report_service import (
     add_report_review,
     approve_report,
@@ -19,8 +23,6 @@ from utils.limiter import limiter
 
 router = APIRouter(prefix="/incident/reports", tags=["Incident Management Subsystem"])
 
-class ResolveReportRequest(BaseModel):
-    resolution: str
 
 @router.post("/", summary="Create a new incident report", response_model=str)
 @limiter.limit("10/minute")
@@ -75,14 +77,22 @@ async def publish_report(request: Request, report_id: str, db=Depends(get_db)):
 @router.put("/{report_id}/review", summary="Add a report review", response_model=str)
 @limiter.limit("10/minute")
 async def review_report(
-    request: Request, report_id: str, review_data: ReportReviewCreate, db=Depends(get_db)
+    request: Request,
+    report_id: str,
+    review_data: ReportReviewCreate,
+    db=Depends(get_db),
 ):
     return await add_report_review(report_id, review_data, db)
 
 
-@router.put("/{report_id}/resolve", summary="Resolve a report review", response_model=str)
+@router.put(
+    "/{report_id}/resolve", summary="Resolve a report review", response_model=str
+)
 @limiter.limit("10/minute")
 async def resolve_report(
-    request: Request, report_id: str, resolution: ResolveReportRequest, db=Depends(get_db)
+    request: Request,
+    report_id: str,
+    resolution: ResolveReportRequest,
+    db=Depends(get_db),
 ):
     return await resolve_report_review(report_id, resolution.resolution, db)

--- a/services/report_service.py
+++ b/services/report_service.py
@@ -3,7 +3,14 @@ from typing import Any, Dict, List
 
 from bson import ObjectId
 from fastapi import HTTPException
-from models.report import ReportCreate, ReportResponse, ReportReview, ReportReviewCreate, ReportReviewStatus, ReportStatus
+from models.report import (
+    ReportCreate,
+    ReportResponse,
+    ReportReview,
+    ReportReviewCreate,
+    ReportReviewStatus,
+    ReportStatus,
+)
 
 
 def convert_string_ids_to_objectid(data: Dict[str, Any]) -> Dict[str, Any]:
@@ -145,8 +152,13 @@ async def update_report(report_id: str, report: ReportCreate, db) -> str:
     if not report_data:
         raise HTTPException(status_code=404, detail="Report not found")
 
-    if report_data.get("status") == "Published" or report_data.get("status") == "Submitted":
-        raise HTTPException(status_code=400, detail="Cannot modify a submitted or published report")
+    if (
+        report_data.get("status") == "Published"
+        or report_data.get("status") == "Submitted"
+    ):
+        raise HTTPException(
+            status_code=400, detail="Cannot modify a submitted or published report"
+        )
 
     update_data = report.model_dump(exclude_unset=True)
 
@@ -249,9 +261,12 @@ async def add_report_review(report_id: str, review_data: ReportReviewCreate, db)
     report_data = await db["reports"].find_one({"_id": object_id})
     if not report_data:
         raise HTTPException(status_code=404, detail="Report not found")
-    
+
     if report_data.get("status") == "Changes Requested":
-        raise HTTPException(status_code=400, detail="Cannot review a report that is already under review")
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot review a report that is already under review",
+        )
 
     review = ReportReview(
         **review_data.model_dump(),
@@ -264,7 +279,7 @@ async def add_report_review(report_id: str, review_data: ReportReviewCreate, db)
 
     await db["reports"].update_one({"_id": object_id}, {"$set": report_data})
     return report_id
-    
+
 
 async def resolve_report_review(report_id: str, resolution: str, db) -> str:
     try:


### PR DESCRIPTION
This PR tackles the BE for the entire Report Review Mgmt Module.

Issues addressed:
- https://careconnectsg.atlassian.net/browse/CACO-285
- https://careconnectsg.atlassian.net/browse/CACO-287

Main Updates:
- Updated report status to now be: draft, submitted, changes requested (review), changes made (resolve), published/approved
- Added in models for report reviews + refactored existing report model to distinguish created date, submitted date, published date, last updated date, etc.
- Add in functions & endpoints for approving a report, adding a review to a report, and resolving a review for a report