### PR TITLE
feat: add reminder_minutes field to activity models and update error message in activity service

### DIFF
--- a/models/activity.py
+++ b/models/activity.py
@@ -15,6 +15,7 @@ class ActivityBase(BaseModel):
     category: Optional[str] = None
     tags: Optional[str] = None
     visibility: bool = True
+    reminder_minutes: Optional[int] = None
 
 
 class ActivityCreate(ActivityBase):
@@ -25,6 +26,7 @@ class ActivityUpdate(ActivityBase):
     title: Optional[str] = None
     start_time: Optional[datetime] = None
     end_time: Optional[datetime] = None
+    reminder_minutes: Optional[int] = None
 
 
 class ActivityResponse(ActivityBase, ModelConfig):
@@ -32,11 +34,3 @@ class ActivityResponse(ActivityBase, ModelConfig):
     created_by: Optional[PyObjectId] = None
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
-
-
-class ActivityFilter(BaseModel):
-    start_date: Optional[datetime] = None
-    end_date: Optional[datetime] = None
-    category: Optional[str] = None
-    tags: Optional[str] = None
-    search: Optional[str] = None

--- a/routers/activity.py
+++ b/routers/activity.py
@@ -3,7 +3,11 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, Query, Request, status
 
-from models.activity import ActivityCreate, ActivityResponse, ActivityUpdate
+from models.activity import (
+    ActivityCreate,
+    ActivityResponse,
+    ActivityUpdate,
+)
 from services import activity_service
 from services.user_service import get_current_user
 from utils.limiter import limiter
@@ -63,7 +67,6 @@ async def update_activity(
     current_user: dict = Depends(get_current_user),
     request: Request = None,
 ):
-
     return await activity_service.update_activity(
         activity_id, activity_update, current_user, request
     )

--- a/services/activity_service.py
+++ b/services/activity_service.py
@@ -159,7 +159,7 @@ async def delete_activity(
         db = await get_db(request)
         existing = await db[collection_name].find_one({"_id": ObjectId(activity_id)})
         if not existing:
-            raise HTTPException(status_code=404, detail="ActivityResponse not found")
+            raise HTTPException(status_code=404, detail="Activity not found")
 
         user_id = None
         is_admin = False


### PR DESCRIPTION
This pull request includes several changes to the `models/activity.py`, `routers/activity.py`, and `services/activity_service.py` files. The most important changes include adding a new field to the `ActivityBase` model, updating the import statements for better readability, and fixing an error message in the `delete_activity` method.

Changes to `models/activity.py`:

* Added `reminder_minutes` field to `ActivityBase` and `ActivityUpdate` classes. [[1]](diffhunk://#diff-1a9b4639ffb77fa1ded0f2c7ff553757299a459a0c29f3ea561a11b6ee5ccb75R18) [[2]](diffhunk://#diff-1a9b4639ffb77fa1ded0f2c7ff553757299a459a0c29f3ea561a11b6ee5ccb75R29-L42)

Changes to `routers/activity.py`:

* Updated import statements to use multi-line format for better readability.
* Removed unnecessary blank line in `update_activity` function.

Changes to `services/activity_service.py`:

* Fixed error message in `delete_activity` method to correctly reference "Activity" instead of "ActivityResponse".